### PR TITLE
better string exception with repr

### DIFF
--- a/bottle_api_json_formatting/bottle_api_json_formatting.py
+++ b/bottle_api_json_formatting/bottle_api_json_formatting.py
@@ -93,7 +93,7 @@ class JsonFormatting(object):
             }
         if self.debug:
             response_object['debug'] = {
-                    'exception': str(error.exception),
+                    'exception': repr(error.exception),
                     'traceback': error.traceback,
                 }
         json_response = json_dumps(response_object)


### PR DESCRIPTION
###### return exception string into json with str

```
integer division or modulo by zero
```
###### return exception string into json with repr

```
ZeroDivisionError('integer division or modulo by zero',)
```
