### PR TITLE
expose 'default' param from json.dumps for custom serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Error:
 Module Contents
 =============
 
-bottle\_api\_json\_formatting.**JsonFormatting**(*supported\_types=*['\*/\*'], *debug=False*)
+bottle\_api\_json\_formatting.**JsonFormatting**(*supported\_types=*['\*/\*'], *debug=False*, *json_default_encoder=None*)
 
 *supported\_types* allows you to expressly set which Content-Types are acceptable for a json formatted response. When set any Content-Types not in the will be passed through untouched. 
 

--- a/bottle_api_json_formatting/bottle_api_json_formatting.py
+++ b/bottle_api_json_formatting/bottle_api_json_formatting.py
@@ -45,13 +45,14 @@ class JsonFormatting(object):
         }
 
     def __init__(self, supported_types=['*/*'], 
-            debug=False):
+            debug=False, json_default_encoder=None):
         self.debug = debug
         self.app = None
         self.function_type = None
         self.function_original = None
         self.supported_types = supported_types
         self.ALL_TYPES = JsonFormatting.ALL_TYPES
+        self.json_default_encoder = json_default_encoder
 
     def setup(self, app):
         ''' Handle plugin install '''
@@ -72,7 +73,8 @@ class JsonFormatting(object):
             if self.in_supported_types(request.headers.get('Accept', '')):
                 response_object = self.get_response_object(0)
                 response_object['data'] = output
-                json_response = json_dumps(response_object)
+                json_response = json_dumps(response_object,
+                                           default=self.json_default_encoder)
                 response.content_type = 'application/json'
                 return json_response
             else:


### PR DESCRIPTION
`json.dumps` and `simplejson.dumps` both support a `default` parameter to serialize complex types. This commit exposes it on plugin's constructor as `json_default_encoder`. This allows API's to simply return complex objects and let the serializer do all the hard work in a centralized place.
